### PR TITLE
Update imu.c

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -714,11 +714,11 @@ void imuQuaternionHeadfreeTransformVectorEarthToBody(t_fp_vector_def *v)
 
     imuQuaternionMultiplication(&offset, &q, &headfree);
     imuQuaternionComputeProducts(&headfree, &buffer);
-
-    const float x = (buffer.ww + buffer.xx - buffer.yy - buffer.zz) * v->X + 2.0f * (buffer.xy + buffer.wz) * v->Y + 2.0f * (buffer.xz - buffer.wy) * v->Z;
-    const float y = 2.0f * (buffer.xy - buffer.wz) * v->X + (buffer.ww - buffer.xx + buffer.yy - buffer.zz) * v->Y + 2.0f * (buffer.yz + buffer.wx) * v->Z;
-    const float z = 2.0f * (buffer.xz + buffer.wy) * v->X + 2.0f * (buffer.yz - buffer.wx) * v->Y + (buffer.ww - buffer.xx - buffer.yy + buffer.zz) * v->Z;
-
+    
+    const float x = (buffer.ww + buffer.xx + buffer.yy - buffer.zz) * v->X + 2.0f * (buffer.xy - buffer.wz) * v->Y + 2.0f * (buffer.xz + buffer.wy) * v->Z;
+    const float y = 2.0f * (buffer.xy + buffer.wz) * v->X + (buffer.ww - buffer.xx + buffer.yy - buffer.zz) * v->Y + 2.0f * (buffer.yz - buffer.wx) * v->Z;
+    const float z = 2.0f * (buffer.xz - buffer.wy) * v->X + 2.0f * (buffer.yz + buffer.wx) * v->Y + (buffer.ww - buffer.xx - buffer.yy + buffer.zz) * v->Z;
+    
     v->X = x;
     v->Y = y;
     v->Z = z;


### PR DESCRIPTION
The imuQuaternionHeadfreeTransformVectorearthtobody function in /betaflight/src/main/flight/rc.c uses
a formula from classical mathematics, where the positive direction of the rotation angle along the axis is counterclockwise.
But betaflight uses the positive direction of the rotation angle along the axis clockwise. I rewrote the formula.
