### PR TITLE
Update imu.c

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -342,20 +342,10 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
 
 STATIC_UNIT_TESTED void imuUpdateEulerAngles(void)
 {
-    quaternionProducts buffer;
-
-    if (FLIGHT_MODE(HEADFREE_MODE)) {
-       imuQuaternionComputeProducts(&headfree, &buffer);
-
-       attitude.values.roll = lrintf(atan2_approx((+2.0f * (buffer.wx + buffer.yz)), (+1.0f - 2.0f * (buffer.xx + buffer.yy))) * (1800.0f / M_PIf));
-       attitude.values.pitch = lrintf(((0.5f * M_PIf) - acos_approx(+2.0f * (buffer.wy - buffer.xz))) * (1800.0f / M_PIf));
-       attitude.values.yaw = lrintf((-atan2_approx((+2.0f * (buffer.wz + buffer.xy)), (+1.0f - 2.0f * (buffer.yy + buffer.zz))) * (1800.0f / M_PIf)));
-    } else {
        attitude.values.roll = lrintf(atan2_approx(rMat[2][1], rMat[2][2]) * (1800.0f / M_PIf));
        attitude.values.pitch = lrintf(((0.5f * M_PIf) - acos_approx(-rMat[2][0])) * (1800.0f / M_PIf));
        attitude.values.yaw = lrintf((-atan2_approx(rMat[1][0], rMat[0][0]) * (1800.0f / M_PIf)));
-    }
-
+   
     if (attitude.values.yaw < 0) {
         attitude.values.yaw += 3600;
     }


### PR DESCRIPTION
Why add the headfree offset to attitude.values in /betaflight/src/main/flight/imu.c?
Yes, now attitude.values shows the correct direction of the abstract "head" in HEADFREE mode,
but the pidLevel function in /betaflight/src/main/flight/pid.c starts working incorrectly.
STATIC_UNIT_TESTED float pidLevel(int axis, const pidProfile_t *pidProfile, const rollAndPitchTrims_t *angleTrim, float currentPidSetpoint) {
…
//Now here is angle in body coordinates, but attitude.raw in earth coordinates.
    const float errorAngle = angle - ((attitude.raw[axis] - angleTrim->raw[axis]) / 10.0f);
…   
}
Proper flight control in HEADFREE mode is achieved by using the imuQuaternionHeadfreeTransformVectorearthtobody function in /betaflight/src/main/flight/rc.c,
which uses the headfree offset to transfer control signals from earth coordinates to body coordinates but does not use attitude.values in any way.
